### PR TITLE
Add option to specify candidate data location as path

### DIFF
--- a/coordinator-tool/CHANGELOG.md
+++ b/coordinator-tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3
+
+- `new-election` subcommand: Support supplying candidate metadata as paths on the host machine.
+  When specified as a path, the data is registered in the contract under a url pointing to the election server.
+
 ## 0.2.2
 
 - Support decryption when there are no votes.

--- a/coordinator-tool/Cargo.lock
+++ b/coordinator-tool/Cargo.lock
@@ -796,7 +796,7 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "coordinator-tool"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/coordinator-tool/Cargo.toml
+++ b/coordinator-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coordinator-tool"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.74"
 

--- a/coordinator-tool/README.md
+++ b/coordinator-tool/README.md
@@ -80,7 +80,7 @@ The weights are stored in the `initial-weights.csv` file.
 ### Create a new election instance
 
 ```
-election-coordinator new-election --module ../contracts/concordium-governance-committee-election/concordium-out/module.wasm.v1 --threshold 1 --admin ../test-scripts/keys/2yJxX711aDXtit7zMu7PHqUMbtwQ8zm7emaikg24uyZtvLTysj.export --election-start '2024-02-01T00:00:00Z' --election-end '2024-02-07T00:00:00Z' --delegation-string 'This is how you delegate' --manifest-out election-manifest.json --parameters-out election-parameters.json --voters-file initial-weights.csv --guardian 31bTNa42u1zZWag2bknEy7VraeJUozXsJMN1DFjQp7E5YR6a3G --guardian 4PF6BH8bKvM48b8KNYdvGW6Sv3B2nqVRiMnWTj9cvaNHJQeX3D --candidate 'http://localhost:7000/candidate1.json' --candidate 'http://localhost:7000/candidate2.json' --node 'https://grpc.testnet.concordium.com:20000' --base-url https://gcvoting.testnet.concordium.com`
+election-coordinator new-election --module ../contracts/concordium-governance-committee-election/concordium-out/module.wasm.v1 --threshold 1 --admin ../test-scripts/keys/2yJxX711aDXtit7zMu7PHqUMbtwQ8zm7emaikg24uyZtvLTysj.export --election-start '2024-02-01T00:00:00Z' --election-end '2024-02-07T00:00:00Z' --decryption-deadline '2024-02-08T00:00:00Z' --delegation-string 'This is how you delegate' --out ./election-out  --voters-file initial-weights.csv --guardian 31bTNa42u1zZWag2bknEy7VraeJUozXsJMN1DFjQp7E5YR6a3G --guardian 4PF6BH8bKvM48b8KNYdvGW6Sv3B2nqVRiMnWTj9cvaNHJQeX3D --candidate candidates/candidate1.json' --candidate 'http://localhost:7000/candidate2.json' --node 'https://grpc.testnet.concordium.com:20000' --base-url https://gcvoting.testnet.concordium.com`
 ```
 
 The options are the following
@@ -89,17 +89,17 @@ The options are the following
 - `--module` is the path to the compiled election smart contract in `wasm.v1` format
 - `--threshold` is the threshold for the number of guardians needed for decryption of the result of the election
 - `--election-start` and `--election-end` are clear
+- `--decryption-deadline` is the time guardians must register their decryptions before
 - `--delegation-string` is the string that will be used to determine vote delegations
 - `--voters-file` is intended to be the `initial-weights.csv` file for the election
 - `--guardian` (repeated) is guardian account addresses. At least one is needed.
-- `--candidate` (repeated) is a URL to a candidate. The order here matters, since that will be the order
+- `--candidate` (repeated) is a URL or a path to a candidate. The order here matters, since that will be the order
   of selections in the election. The link should be to the candidate metadata. The hash of the metadata will be
   embedded in the contract.
 - `--base-url` the URL where the election server is accessible, e.g., https://gcvoting.testnet.concordium.com
 
 The tool generates three things
-- An election manifest which is output to the location specified by `--manifest-out`
-- Election parameters which are output to the location specified by `--parameters-out`
+- An election manifest + election parameters which are written to the directory specified by `--out`
 - A new smart contract instance which is printed to stderr, for example
 
 ```

--- a/election-server/README.md
+++ b/election-server/README.md
@@ -11,11 +11,12 @@ cargo build --release
 ## Running the http binary
 
 ```bash
-cargo run --bin http --release -- --eligible-voters-file "path/to/voters.json" # and other configration options.
+cargo run --bin http --release -- --contract-address "<7635,0>" # and other configration options.
 ```
 
 ### Configuration
 
+```
 Usage: http [OPTIONS] --contract-address <CONTRACT_ADDRESS>
 
 Options:
@@ -33,14 +34,14 @@ Options:
           Address the http server will listen on [env: CCD_ELECTION_LISTEN_ADDRESS=] [default: 0.0.0.0:8080]
       --prometheus-address <PROMETHEUS_ADDRESS>
           Address of the prometheus server [env: CCD_ELECTION_PROMETHEUS_ADDRESS=]
-      --candidates-metadata-dir <CANDIDATES_METADATA_DIR>
-          A directory holding metadata json files for each candidate [env: CCD_ELECTION_CANDIDATES_METADATA_DIR=] [default: ../resources/config-example/candidates]
       --eligible-voters-file <ELIGIBLE_VOTERS_FILE>
-          A json file consisting of the list of eligible voters and their respective voting weights [env: CCD_ELECTION_ELIGIBLE_VOTERS_FILE=] [default: ../resources/config-example/eligible-voters.json]
+          A csv file consisting of the list of eligible voters and their respective voting weights [env: CCD_ELECTION_ELIGIBLE_VOTERS_FILE=] [default: ../resources/config-example/initial-weights.csv]
       --election-manifest-file <EG_MANIFEST_FILE>
           A json file consisting of the election manifest used by election guard [env: CCD_ELECTION_ELECTION_MANIFEST_FILE=] [default: ../resources/config-example/election-manifest.json]
       --election-parameters-file <EG_PARAMETERS_FILE>
           A json file consisting of the election parameters used by election guard [env: CCD_ELECTION_ELECTION_PARAMETERS_FILE=] [default: ../resources/config-example/election-parameters.json]
+      --candidates-dir <CANDIDATES_DIR>
+          An optional directory with JSON metadata for a set of candidates [env: CCD_ELECTION_CANDIDATES_DIR=]
       --frontend-dir <FRONTEND_DIR>
           Path to the directory where frontend assets are located [env: CCD_ELECTION_FRONTEND_DIR=] [default: ../apps/voting/dist]
       --allow-cors
@@ -51,7 +52,9 @@ Options:
           The contract address of the election contract (passed to frontend) [env: CCD_ELECTION_CONTRACT_ADDRESS=]
   -h, --help
           Print help
-
+  -V, --version
+          Print version
+```
 Example usage (with all defaults applied):
 ```bash
 http --contract-address "<7635,0>"
@@ -65,6 +68,7 @@ cargo run --bin indexer --release -- --contract-address "<7635,0>" # and other c
 
 ### Configuration
 
+```
 Usage: indexer [OPTIONS] --contract-address <CONTRACT_ADDRESS>
 
 Options:
@@ -82,10 +86,13 @@ Options:
           [env: CCD_ELECTION_ELECTION_MANIFEST_FILE=] [default: ../resources/config-example/election-manifest.json]
       --election-parameters-file <EG_PARAMETERS_FILE>
           A json file consisting of the election parameters used by election guard [env: CCD_ELECTION_ELECTION_PARAMETERS_FILE=] [default: ../resources/config-example/election-parameters.json]
-      --guardian-keys-file <EG_GUARDIAN_KEYS_FILE>
-          A json file consisting of the guardian public keys of the election [env: CCD_ELECTION_GUARDIAN_KEYS_FILE=] [default: ../resources/config-example/guardian-public-keys.json]
+      --request-timeout-ms <REQUEST_TIMEOUT_MS>
+          The request timeout of the http server (in milliseconds) [env: CCD_ELECTION_REQUEST_TIMEOUT_MS=] [default: 5000]
   -h, --help
           Print help
+  -V, --version
+          Print version
+```
 
 Example usage (with all defaults applied):
 ```bash


### PR DESCRIPTION
## Purpose

To enable hosting candidate metadata from the election server, we need to not depend on candidate entries being specified as URL's, as these would then need to point to the election server which does not exist at that point in time.

This implements a hybrid solution, where:
- Candidate specified as paths are registered at `"<election-server>/static/concordium/candidates/<file-name.json>"` and will consequently be hosted by the election server.
- Candidates specified as urls are registered in the contract with at `"<url>"` and are assumed to be available at that location for the lifetime of the election.

Closes #104

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
