### PR TITLE
Indexer/store encrypted ballots as bytes

### DIFF
--- a/.github/workflows/check-apps.yml
+++ b/.github/workflows/check-apps.yml
@@ -17,7 +17,7 @@ on:
 env:
   DUMMY: 1 # For cache busting.
   NODE_VERSION: "18.16.0"
-  RUST_VERSION: "1.74"
+  RUST_VERSION: "1.76"
   RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
   CARGO_CONCORDIUM_VERSION: "3.2.0"
   CCD_ELECTION_CONTRACT_ADDRESS: <0,0> # Otherwise build will fail

--- a/.github/workflows/check-crates.yaml
+++ b/.github/workflows/check-crates.yaml
@@ -12,7 +12,7 @@ name: check crates
 
 env:
   RUST_FMT: nightly-2023-04-01
-  RUST_VERSION: "1.74"
+  RUST_VERSION: "1.76"
   CARGO_CONCORDIUM_VERSION: "3.0.0"
   # The following environment variables need to be set for build to succeed.
   CCD_ELECTION_NODE: ""

--- a/.github/workflows/release-coordinator.yml
+++ b/.github/workflows/release-coordinator.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           submodules: recursive
       - name: Install rust toolchain
-        uses: dtolnay/rust-toolchain@1.74
+        uses: dtolnay/rust-toolchain@1.76
       - name: Build election-coordinator binary
         run: cargo build --release --manifest-path coordinator-tool/Cargo.toml
       - name: Upload artifact

--- a/coordinator-tool/src/bin/election-coordinator.rs
+++ b/coordinator-tool/src/bin/election-coordinator.rs
@@ -785,7 +785,7 @@ async fn handle_reset(
     let confirm = dialoguer::Confirm::new()
         .report(true)
         .wait_for_newline(true)
-        .with_prompt("Confirm excluding guardians.")
+        .with_prompt("Confirm tally decryption reset.")
         .interact()?;
     anyhow::ensure!(confirm, "Aborting.");
 

--- a/election-server/CHANGELOG.md
+++ b/election-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+- Fix unicode escape error from postgres by storing encrypted ballots as `BYTEA` instead of `JSONB`.
+
 ## 0.2.2
 
 - Update concordium rust dependencies

--- a/election-server/Cargo.lock
+++ b/election-server/Cargo.lock
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "election-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum 0.7.4",

--- a/election-server/Cargo.toml
+++ b/election-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "election-server"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Concordium software <support@concordium.software>"]
 edition = "2021"
 

--- a/election-server/resources/schema.sql
+++ b/election-server/resources/schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS ballots (
   id INT8 PRIMARY KEY, -- For pagination
   transaction_hash BYTEA NOT NULL,
   block_time TIMESTAMP WITH TIME ZONE NOT NULL,
-  ballot JSONB NOT NULL,
+  ballot BYTEA NOT NULL,
   account BYTEA NOT NULL,
   verified BOOL NOT NULL
 );

--- a/election-server/src/bin/indexer.rs
+++ b/election-server/src/bin/indexer.rs
@@ -209,9 +209,10 @@ async fn run_db_process(
                 Ok(time) => {
                     successive_db_errors = 0;
                     tracing::info!(
-                        "Processed block {} at height {} transactions in {}ms",
+                        "Processed block {} at height {} with {} transactions in {}ms",
                         block_data.block_hash,
                         block_data.height.height,
+                        block_data.transactions.len(),
                         time.num_milliseconds()
                     );
                     retry_block_data = None;
@@ -328,7 +329,7 @@ async fn set_shutdown(flag: Arc<AtomicBool>) -> anyhow::Result<()> {
 }
 
 /// Extracts the relevant [`TransactionData`] (if any) from `transaction`.
-#[tracing::instrument(skip(transaction), fields(tx_hash = %transaction.hash))]
+#[tracing::instrument(skip_all, fields(tx_hash = %transaction.hash))]
 fn get_transaction_data(
     transaction: BlockItemSummary,
     contract_address: &ContractAddress,

--- a/election-server/src/db.rs
+++ b/election-server/src/db.rs
@@ -6,11 +6,9 @@ use concordium_rust_sdk::{
 };
 use deadpool_postgres::{GenericClient, Object};
 use eg::ballot::BallotEncrypted;
+use election_common::{decode, encode};
 use serde::Serialize;
-use tokio_postgres::{
-    types::{Json, ToSql},
-    NoTls,
-};
+use tokio_postgres::{types::ToSql, NoTls};
 
 use crate::util::{BallotSubmission, VotingWeightDelegation};
 
@@ -86,13 +84,16 @@ impl TryFrom<tokio_postgres::Row> for StoredBallotSubmission {
         let id: i64 = value.try_get(0)?;
         let raw_transaction_hash: &[u8] = value.try_get(1)?;
         let block_time: DateTime<Utc> = value.try_get(2)?;
-        let Json(ballot) = value.try_get(3)?;
+        let raw_ballot: &[u8] = value.try_get(3)?;
         let raw_account: &[u8] = value.try_get(4)?;
         let verified: bool = value.try_get(5)?;
 
         let account_bytes: [u8; ACCOUNT_ADDRESS_SIZE] = raw_account
             .try_into()
             .map_err(|_| DatabaseError::TypeConversion)?;
+
+        let ballot: BallotEncrypted =
+            decode(raw_ballot).map_err(|e| DatabaseError::Other(format!("{e}")))?;
 
         let stored_ballot = Self {
             id: id as u64,
@@ -359,7 +360,7 @@ impl<'a> Transaction<'a> {
         let params: [&(dyn ToSql + Sync); 5] = [
             &ballot.transaction_hash.as_ref(),
             &block_time,
-            &Json(&ballot.ballot),
+            &encode(&ballot.ballot).map_err(|e| DatabaseError::Other(format!("{e}")))?,
             &ballot.account.0.as_ref(),
             &ballot.verified,
         ];

--- a/scripts/dapp-gc-voting.Dockerfile
+++ b/scripts/dapp-gc-voting.Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile is meant to be run from the **root of the repository**.
 
 ARG build_image=node:18-slim
-ARG rust_version=1.74
+ARG rust_version=1.76
 ARG rust_base_image=rust:${rust_version}-buster
 
 FROM --platform=linux/amd64 ${rust_base_image} AS backend

--- a/scripts/indexer.Dockerfile
+++ b/scripts/indexer.Dockerfile
@@ -1,7 +1,7 @@
 # This dockerfile is meant to be run from the **root of the repository**.
 # It builds a docker image that contains the indexer.
 
-ARG rust_version=1.74
+ARG rust_version=1.76
 ARG rust_base_image=rust:${rust_version}-buster
 
 FROM --platform=linux/amd64 ${rust_base_image} AS backend


### PR DESCRIPTION
## Purpose

Fixes bug found during stress test of election setup explained in changes below.

## Changes

- Fix unicode escape error from postgres by storing encrypted ballots as `BYTEA` instead of `JSONB`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
