### PR TITLE
Voting dapp/fix duplicate requests

### DIFF
--- a/apps/voting/CHANGELOG.md
+++ b/apps/voting/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix an issue with duplicate requests being done on application load
+
 ## 0.2.5
 
 - Fix issue where walletconnect modal would not connect properly.

--- a/apps/voting/src/pages/Home/Home.tsx
+++ b/apps/voting/src/pages/Home/Home.tsx
@@ -4,18 +4,18 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Card, Col, Modal, Row, Image, Spinner } from 'react-bootstrap';
 import { Buffer } from 'buffer/index.js';
 
-import { getElectionResult, registerVotes } from '~/shared/election-contract';
+import { registerVotes } from '~/shared/election-contract';
 import {
     IndexedCandidateDetails,
     addSubmittedBallotAtom,
     electionConfigAtom,
     connectionViewAtom,
     activeWalletAtom,
+    electionResultAtom,
 } from '~/shared/store';
 import { ElectionOpenState, useIsElectionOpen } from '~/shared/hooks';
 import { useElectionGuard } from '~/shared/election-guard';
 import CheckIcon from '~/assets/rounded-success.svg?react';
-import { useAsyncMemo } from 'shared/util';
 import { Explain } from 'shared/components';
 
 interface CandidateProps {
@@ -91,7 +91,7 @@ export default function Home() {
     const isElectionOpen = electionState === ElectionOpenState.Open;
     const { getEncryptedBallot } = useElectionGuard();
     const [loading, setLoading] = useState(false);
-    const electionResult = useAsyncMemo(getElectionResult, console.error, []);
+    const electionResult = useAtomValue(electionResultAtom);
     const candidates = useMemo(() => {
         if (electionResult !== undefined && electionConfig?.candidates !== undefined) {
             const res = [...electionConfig.candidates];

--- a/apps/voting/src/shared/election-contract.tsx
+++ b/apps/voting/src/shared/election-contract.tsx
@@ -90,3 +90,5 @@ export async function getElectionResult() {
 
     return parsed.content;
 }
+
+export type ElectionResultResponse = Awaited<ReturnType<typeof getElectionResult>>;

--- a/apps/voting/src/shared/store.ts
+++ b/apps/voting/src/shared/store.ts
@@ -15,7 +15,7 @@ import { ElectionManifest, ElectionParameters } from 'electionguard-bindings';
 import { ResourceVerificationError, expectValue, getChecksumResource, isDefined } from 'shared/util';
 import { ChecksumUrl, GuardianPublicKey } from 'shared/types';
 
-import { getElectionConfig, getGuardiansState } from './election-contract';
+import { ElectionResultResponse, getElectionConfig, getElectionResult, getGuardiansState } from './election-contract';
 import { pollUntil } from './util';
 import { NETWORK } from './constants';
 import {
@@ -471,6 +471,19 @@ export const loadMoreSubmittedBallotsAtom = atom(null, async (get, set) => {
     set(localBallotsAtom, { hasMore, lastIndex: last?.id, ballots: [...localFiltered, ...remoteBallots] });
 });
 
+const electionResultBaseAtom = atom<ElectionResultResponse>(undefined);
+
+/**
+ * Holds the election result from the election contract, if available. Invoke setter to refresh the value from the
+ * contract
+ */
+export const electionResultAtom = atom(
+    (get) => get(electionResultBaseAtom),
+    async (_, set) => {
+        set(electionResultBaseAtom, await getElectionResult());
+    },
+);
+
 /**
  * Initializes the global store with data fetched from the backend
  */
@@ -478,6 +491,7 @@ export function initStore() {
     const store = createStore();
 
     void store.set(electionConfigAtom);
+    void store.set(electionResultAtom);
 
     return store;
 }

--- a/apps/voting/src/shell/Root.tsx
+++ b/apps/voting/src/shell/Root.tsx
@@ -1,18 +1,10 @@
-import { Provider, createStore, useAtomValue } from 'jotai';
+import { Provider } from 'jotai';
 import { RouterProvider } from 'react-router-dom';
 import { WalletConnectionManager } from '~/shared/wallet-connection';
-import { electionConfigAtom } from '~/shared/store';
+import { initStore } from '~/shared/store';
 import { router } from './router';
 
-const store = createStore();
-
-/**
- * Component which ensures selected parts of global state stays in memory for the lifetime of the application
- */
-function EnsureGlobalState() {
-    useAtomValue(electionConfigAtom);
-    return null;
-}
+const store = initStore();
 
 /**
  * The application root. This is in charge of setting up global contexts to be available from {@linkcode App} and
@@ -22,7 +14,6 @@ function Root() {
     return (
         <Provider store={store}>
             <WalletConnectionManager>
-                <EnsureGlobalState />
                 <RouterProvider router={router} />
             </WalletConnectionManager>
         </Provider>


### PR DESCRIPTION
Closes #136 

## Changes

- Ensure requests only happen once
- Lower the time before the application shows the election data by executing and updating "viewConfig" and "viewGuardiansState" sequentially instead of in parallel (as guardians state takes a while to decode)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
