### PR TITLE
Change the default timeout 10s

### DIFF
--- a/apps/guardian/CHANGELOG.md
+++ b/apps/guardian/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Change the default request timeout to 10s.
+
 ## 2.0.1
 
 ### Fixed

--- a/apps/guardian/README.md
+++ b/apps/guardian/README.md
@@ -35,7 +35,7 @@ yarn install
 The following environment variables can be provided optionally:
 
 ```env
-CCD_ELECTION_REQUEST_TIMEOUT_MS=5000 # Defaults to 5000
+CCD_ELECTION_REQUEST_TIMEOUT_MS=5000 # Defaults to 10000
 ```
 
 ## Development workflow

--- a/apps/guardian/src-tauri/src/shared.rs
+++ b/apps/guardian/src-tauri/src/shared.rs
@@ -156,4 +156,4 @@ impl GenesisHash for Network {
 
 /// The default request timeout to use if not specified by environment variable
 /// "CCD_ELECTION_REQUEST_TIMEOUT_MS".
-pub const DEFAULT_REQUEST_TIMEOUT_MS: u16 = 5000;
+pub const DEFAULT_REQUEST_TIMEOUT_MS: u16 = 10000;

--- a/election-server/CHANGELOG.md
+++ b/election-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Change the default request timeout to 10s.
+
 ## 1.0.1
 
 - Bumped rust-sdk dependency to 6.0

--- a/election-server/README.md
+++ b/election-server/README.md
@@ -43,7 +43,7 @@ Options:
       --log-level <LOG_LEVEL>
           Maximum log level [env: CCD_ELECTION_LOG_LEVEL=] [default: info]
       --request-timeout-ms <REQUEST_TIMEOUT_MS>
-          The request timeout of the http server (in milliseconds) [env: CCD_ELECTION_REQUEST_TIMEOUT_MS=] [default: 5000]
+          The request timeout of the http server (in milliseconds) [env: CCD_ELECTION_REQUEST_TIMEOUT_MS=] [default: 10000]
       --listen-address <LISTEN_ADDRESS>
           Address the http server will listen on [env: CCD_ELECTION_LISTEN_ADDRESS=] [default: 0.0.0.0:8080]
       --prometheus-address <PROMETHEUS_ADDRESS>
@@ -89,7 +89,7 @@ Options:
       --max-behind-seconds <MAX_BEHIND_S>
           Max amount of seconds a response from a node can fall behind before trying another [env: CCD_ELECTION_MAX_BEHIND_SECONDS=] [default: 240]
       --request-timeout-ms <REQUEST_TIMEOUT_MS>
-          The request timeout of the http server (in milliseconds) [env: CCD_ELECTION_REQUEST_TIMEOUT_MS=] [default: 5000]
+          The request timeout of the http server (in milliseconds) [env: CCD_ELECTION_REQUEST_TIMEOUT_MS=] [default: 10000]
   -h, --help
           Print help
   -V, --version

--- a/election-server/src/bin/http.rs
+++ b/election-server/src/bin/http.rs
@@ -78,7 +78,7 @@ struct AppConfig {
     /// The request timeout of the http server (in milliseconds)
     #[clap(
         long = "request-timeout-ms",
-        default_value_t = 5000,
+        default_value_t = 10000,
         env = "CCD_ELECTION_REQUEST_TIMEOUT_MS"
     )]
     request_timeout_ms: u64,

--- a/election-server/src/bin/indexer.rs
+++ b/election-server/src/bin/indexer.rs
@@ -81,7 +81,7 @@ struct AppConfig {
     /// The request timeout of the http server (in milliseconds)
     #[clap(
         long = "request-timeout-ms",
-        default_value_t = 5000,
+        default_value_t = 10000,
         env = "CCD_ELECTION_REQUEST_TIMEOUT_MS"
     )]
     request_timeout_ms: u64,


### PR DESCRIPTION
It proved an issue with a configuration consisting of 11 guardians and 10 candidates, which is the current theoretical max

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
